### PR TITLE
fix(rmq): race condition in handleReconnect and double reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Fixed
+
+- **rabbitmq**: Race condition in `handleReconnect` - connection reference now captured under lock before use (#17)
+- **rabbitmq**: Double reconnect bug - `handleReconnect` now starts once in `NewConnection` instead of `connect()` (#17)
+- **rabbitmq**: Added `NotifyBlocked` handler for server blocked/unblocked events (#17)

--- a/internal/infra/messagebus/rabbitmq/connection.go
+++ b/internal/infra/messagebus/rabbitmq/connection.go
@@ -39,6 +39,8 @@ func NewConnection(cfg Config, log *zerolog.Logger) (*Connection, error) {
 		return nil, fmt.Errorf("%w: %w", ErrConnection, err)
 	}
 
+	go c.handleReconnect()
+
 	return c, nil
 }
 
@@ -147,9 +149,6 @@ func (c *Connection) connect() error {
 		Str("vhost", c.config.VHost).
 		Msg("Connected to RabbitMQ")
 
-	// Start connection monitoring
-	go c.handleReconnect()
-
 	return nil
 }
 
@@ -175,11 +174,13 @@ func (c *Connection) buildTLSConfig() (*tls.Config, error) {
 func (c *Connection) handleReconnect() {
 	for {
 		c.mu.RLock()
-		if c.conn == nil {
+		conn := c.conn
+		if conn == nil {
 			c.mu.RUnlock()
 			return
 		}
-		notifyClose := c.conn.NotifyClose(make(chan *amqp.Error, 1))
+		notifyClose := conn.NotifyClose(make(chan *amqp.Error, 1))
+		notifyBlocked := conn.NotifyBlocked(make(chan amqp.Blocking, 1))
 		c.mu.RUnlock()
 
 		select {
@@ -198,6 +199,14 @@ func (c *Connection) handleReconnect() {
 				c.attemptReconnect()
 			}
 			return
+		case blocked := <-notifyBlocked:
+			if blocked.Active {
+				c.log.Warn().
+					Str("reason", blocked.Reason).
+					Msg("RabbitMQ connection blocked by server")
+			} else {
+				c.log.Info().Msg("RabbitMQ connection unblocked")
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Fix race condition in `handleReconnect` by storing connection reference under lock
- Fix double reconnect bug by moving `handleReconnect` startup to `NewConnection`
- Add `NotifyBlocked` handler for server blocked/unblocked events

## Changes

### `connection.go`

1. **Race condition fix**: Store `c.conn` in local variable `conn` under RLock before using it
2. **Double reconnect fix**: `handleReconnect()` now starts once in `NewConnection()` instead of `connect()`
3. **Blocked handling**: Added `NotifyBlocked` channel to handle server resource alarms

### `CHANGELOG.md`

- Created changelog file following [Keep a Changelog](https://keepachangelog.com/) format

## Testing

- `make lint` - ✅ 0 issues
- `make test` - ✅ All tests pass

Closes #17